### PR TITLE
Various recipe changes and tweaks.

### DIFF
--- a/steel/init.lua
+++ b/steel/init.lua
@@ -41,7 +41,7 @@ end
 
 function steel_rotate_and_place(itemstack, placer, pointed_thing)
 
-	local node = minetest.env:get_node(pointed_thing.under)
+	local node = minetest.get_node(pointed_thing.under)
 	if not minetest.registered_nodes[node.name] or not minetest.registered_nodes[node.name].on_rightclick then
 		if steel_node_is_owned(pointed_thing.above, placer) then
 			return itemstack
@@ -49,8 +49,8 @@ function steel_rotate_and_place(itemstack, placer, pointed_thing)
 		local above = pointed_thing.above
 		local under = pointed_thing.under
 		local pitch = placer:get_look_pitch()
-		local node = minetest.env:get_node(above)
-		local fdir = minetest.env:dir_to_facedir(placer:get_look_dir())
+		local node = minetest.get_node(above)
+		local fdir = minetest.dir_to_facedir(placer:get_look_dir())
 		local wield_name = itemstack:get_name()
 
 		if node.name ~= "air" then return end
@@ -60,11 +60,11 @@ function steel_rotate_and_place(itemstack, placer, pointed_thing)
 
 		if iswall then 
 			local dirs = { 2, 3, 0, 1 }
-			minetest.env:add_node(above, {name = wield_name.."_wall", param2 = dirs[fdir+1] }) -- place wall variant
+			minetest.add_node(above, {name = wield_name.."_wall", param2 = dirs[fdir+1] }) -- place wall variant
 		elseif isceiling then
-			minetest.env:add_node(above, {name = wield_name.."_wall", param2 = 19 }) -- place wall variant on ceiling
+			minetest.add_node(above, {name = wield_name.."_wall", param2 = 19 }) -- place wall variant on ceiling
 		else
-			minetest.env:add_node(above, {name = wield_name }) -- place regular variant
+			minetest.add_node(above, {name = wield_name }) -- place regular variant
 		end
 
 		if not steel_expect_infinite_stacks then

--- a/steel/rust.lua
+++ b/steel/rust.lua
@@ -5,8 +5,8 @@ local function moss(input, output)
 		interval = 50,
 		chance = 20,
 		action = function(pos)
-			if not minetest.env:find_node_near(pos, 3, output) then
-				minetest.env:add_node(pos, {name=output})
+			if not minetest.find_node_near(pos, 3, output) then
+				minetest.add_node(pos, {name=output})
 			end
 		end,
 	})


### PR DESCRIPTION
this makes the scraps-to-iron-lump recipe require 4 portions of scraps instead of 2, if Technic mod is present (to prevent an infinite loop), crafts steel ingots in a line directly to a sheet metal item first, and then that can be crafted into corrugated steel, and replaces all single quotes with double quotes for consistency.
